### PR TITLE
Update TLS 1.2 ciphers and TLS 1.3 ciphers order

### DIFF
--- a/client/CryptoManager.cpp
+++ b/client/CryptoManager.cpp
@@ -78,23 +78,11 @@ static bool hardware_gcm(void) {
 }
 
 static const char g_ciphersuites[] =
-    "ECDHE-ECDSA-AES128-GCM-SHA256:"
+	
     "ECDHE-RSA-AES128-GCM-SHA256:"
-    "ECDHE-ECDSA-AES128-SHA256:"
+    "ECDHE-ECDSA-AES128-GCM-SHA256:"
     "ECDHE-RSA-AES128-SHA256:"
-    "ECDHE-ECDSA-AES128-SHA:"
-    "ECDHE-RSA-AES128-SHA:"
-    "DHE-RSA-AES128-SHA:"
-    "AES128-SHA:"
-    "ECDHE-ECDSA-AES256-GCM-SHA384:"
-    "ECDHE-RSA-AES256-GCM-SHA384:"
-    "ECDHE-ECDSA-AES256-SHA384:"
-    "ECDHE-RSA-AES256-SHA384:"
-    "ECDHE-ECDSA-AES256-SHA:"
-    "ECDHE-RSA-AES256-SHA:"
-    "AES256-GCM-SHA384:"
-    "AES256-SHA256:"
-    "AES256-SHA";
+    "ECDHE-ECDSA-AES256-GCM-SHA384";
     
 CryptoManager::CryptoManager()
 	:
@@ -177,8 +165,8 @@ void CryptoManager::setContextOptions(SSL_CTX* aCtx, bool aServer) {
 	// https://github.com/pavel-pimenov/flylinkdc-r5xx/issues/1737
 	const char ciphersuitesTls13[] =
 	    "TLS_AES_128_GCM_SHA256:"
-	    "TLS_AES_256_GCM_SHA384:"
-	    "TLS_CHACHA20_POLY1305_SHA256";
+	    "TLS_CHACHA20_POLY1305_SHA256:"
+	    "TLS_AES_256_GCM_SHA384";
 	    
 	SSL_CTX_set_ciphersuites(aCtx, ciphersuitesTls13);
 #endif


### PR DESCRIPTION
https://sourceforge.net/p/dcplusplus/code/ci/dc0f387ed4958d0f15da7e89f15a17e31ef9997e/
https://dcpp.wordpress.com/2020/03/07/dc-0-8681-will-require-tls-1-2-or-tls-1-3/